### PR TITLE
Add Password Change Timestamp

### DIFF
--- a/app/System/Libraries/Auth/Auth.php
+++ b/app/System/Libraries/Auth/Auth.php
@@ -393,7 +393,7 @@ class Auth {
                         // Everything looks good, sign user up
                         $password = $this->hashPass($password);
                         $activekey = $this->randomKey(RANDOM_KEY_LENGTH); // Create a random key for account activation
-                        $info = array("username" => $username, "password" => $password, "email" => $email, "activekey" => $activekey, "userImage"=>"default-".rand(1,5).".jpg");
+                        $info = array("username" => $username, "password" => $password, "email" => $email, "activekey" => $activekey, "userImage"=>"default-".rand(1,5).".jpg", "pass_change_timestamp" => date("Y-m-d H:i:s"));
                         $user_id = $this->authorize->addIntoDB("users", $info);
 
                         $info = array('userID' => $user_id, 'groupID' => 1);
@@ -490,7 +490,7 @@ class Auth {
                         // Email address isn't already used
                         $password = $this->hashPass($password);
                         $activekey = $this->randomKey(RANDOM_KEY_LENGTH);
-                        $info = array("username" => $username, "password" => $password, "email" => $email, "activekey" => $activekey, "userImage"=>"default-".rand(1,5).".jpg");
+                        $info = array("username" => $username, "password" => $password, "email" => $email, "activekey" => $activekey, "userImage"=>"default-".rand(1,5).".jpg", "pass_change_timestamp" => date("Y-m-d H:i:s"));
                         $user_id = $this->authorize->addIntoDB("users", $info);
 
                         $info = array('userID' => $user_id, 'groupID' => 1);
@@ -710,7 +710,7 @@ class Auth {
                 $db_currpass = $query[0]->password;
                 $verify_password = \Libs\Password::verify($currpass, $db_currpass);
                 if ($verify_password) {
-                    $info = array("password" => $newpass);
+                    $info = array("password" => $newpass, "pass_change_timestamp" => date("Y-m-d H:i:s"));
                     $where = array("username" => $username);
                     $this->authorize->updateInDB('users',$info,$where);
                     $this->logActivity($username, "AUTH_CHANGEPASS_SUCCESS", "Password changed");

--- a/database.sql
+++ b/database.sql
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS `uap4_users` (
   `userID` int(11) NOT NULL AUTO_INCREMENT,
   `username` varchar(30) DEFAULT NULL,
   `password` varchar(128) DEFAULT NULL,
+  `pass_change_timestamp` datetime DEFAULT NULL,
   `email` varchar(100) DEFAULT NULL,
   `firstName` varchar(100) DEFAULT NULL,
   `lastName` varchar(100) DEFAULT NULL,


### PR DESCRIPTION
Added Password Change Timestamp to the database, register, and change
password pages.

Will add feature that allows admin to setup when users should be
reminded to change their passwords after a given time.